### PR TITLE
Add creating build forlder

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/entry.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "assets": "cp -r assets/* build/",
+    "assets": "mkdir -p build && cp -r assets/* build/",
     "webpack": "webpack --progress --colors",
     "start": "node node_modules/http-server/bin/http-server build",
     "build": "npm run assets && npm run webpack && npm start"


### PR DESCRIPTION
After cloning this repo it's impossible to run it because of absent build folder.
```mkdir -p``` will create folder if it doesn't exists